### PR TITLE
cytoscape/cytoscape#35: Use HTTPS repos, drop EBI psidev repository from third-party

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -59,7 +59,7 @@
         <repository>
           <id>central</id>
           <name>Central Repository</name>
-          <url>http://repo.maven.apache.org/maven2</url>
+          <url>https://repo.maven.apache.org/maven2</url>
           <releases>
             <enabled>true</enabled>
           </releases>

--- a/third-party/pom.xml
+++ b/third-party/pom.xml
@@ -44,17 +44,24 @@
           <name>Cytoscape Releases</name>
           <url>https://nrnb-nexus.ucsd.edu/repository/cytoscape_releases/</url>
        </repository>
-       <repository>
-          <id>psidev</id>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-          <releases>
-            <enabled>true</enabled>
-          </releases>
-          <name>psidev</name>
-          <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-release/</url>
-       </repository>
+       <!--
+          Deliberately NOT declaring EBI's 'psidev' repository here.
+
+          psidev.psi.mi:psi25-xml is served by cytoscape_thirdparty (inherited
+          from the parent POM) as a stripped POM with no parent and no
+          dependencies. EBI serves the real POM, whose parent psimi-master
+          declares a long list of dead plain-http repositories (intact.nexus,
+          ebi-repo, springsource, codehaus, download.java.net,
+          pride-proteomics) and pulls in cpdetector and the SpringSource
+          commons-logging/log4j bundles, which exist only on those hosts.
+          Maven 3.8.1+ blocks http repositories, so on a machine that has not
+          already cached the stripped POM the build fails while collecting
+          third-party's dependencies.
+
+          Declaring psidev here put it ahead of cytoscape_thirdparty in the
+          resolution order, so the real POM won and the build broke on any
+          clean checkout. See cytoscape/cytoscape#35.
+       -->
   </repositories>
 
   <dependencies>


### PR DESCRIPTION
Part of the multi-repository fix for cytoscape/cytoscape#35. Main description and full verification: **cytoscape/cytoscape#36**.

This PR is independent of the others and can merge in any order.

## Changes

**Use HTTPS for Maven repositories** in `.travis.settings.xml`; Maven 3.8.1+ blocks plain http. Repository ids are unchanged, so cached artifacts stay valid.

**Drop EBI's `psidev` repository from `third-party`.** This one is subtle and is worth reading before approving.

`third-party` depends on `psidev.psi.mi:psi25-xml:1.8.6`, and two different POMs exist for that artifact:

| Source | Size | Contents |
|---|---|---|
| `cytoscape_thirdparty` (our nexus) | 360 bytes | stripped — no parent, no dependencies |
| `psidev` (EBI) | 8448 bytes | real — parent `psimi-master`, 12 dependencies |

Someone published the stripped POM to our nexus precisely so this artifact does not drag its tree in. But this POM also declared EBI's `psidev` repository, which put it **ahead of** the inherited `cytoscape_thirdparty` in resolution order. So EBI answers first, Maven reads the real POM, and its parent `psimi-master` contributes a list of long-dead plain-http repositories — intact.nexus, nexus-ebi-release-repo, ebi-repo, springsource, download.java.net, pride-proteomics, codehaus — plus `cpdetector` and the SpringSource commons-logging/log4j bundles, which are hosted only there. Maven 3.8.1+ blocks all of them:

```
[ERROR] Failed to read artifact descriptor for cpdetector:cpdetector:jar:1.0.7
[ERROR]   Blocked mirror for repositories: [intact.nexus (http://...), ...]
```

A developer machine with a warm `~/.m2` already holds the stripped POM and never re-resolves it, so this only shows up on a clean machine — it was found on a fresh Ubuntu VM, not locally. `cytoscape_thirdparty` serves both the stripped POM and the jar (verified, both HTTP 200), so the repository is simply removed and a comment records why it must not come back.

## Verification

Reproduced locally by clearing only `~/.m2/repository/psidev`, which gave the VM's error byte-for-byte; with the repository removed, the 360-byte stub is fetched from `cytoscape_thirdparty` and the module resolves.

Verified as part of the full seven-repository build on `develop` against a genuinely empty local repository with no settings file: 122 SUCCESS / 0 FAILURE on both passes, zero blocked-mirror errors. Details in cytoscape/cytoscape#36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Central Repository connection to use HTTPS for improved security.
  * Simplified third-party dependency repository configuration and clarified the repository setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->