### PR TITLE
Update cy-ndex-2 version from 3.7.4 to 3.7.5

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -562,7 +562,7 @@
 								<artifactItem>
 									<groupId>org.cytoscape</groupId>
 									<artifactId>cy-ndex-2</artifactId>
-									<version>3.7.4</version>
+									<version>3.7.5</version>
 									<type>jar</type>
 								</artifactItem>
 								<artifactItem>


### PR DESCRIPTION
bump to new version [3.7.5 of cy-ndex-2](https://github.com/cytoscape/cy-ndex-2/releases/tag/3.7.5) which has fix for accessing public networks when no profiles exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `cy-ndex-2` dependency to version 3.7.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->